### PR TITLE
Release v0.5.0.beta0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## [0.5.0.beta0] - 2024-06-07
+
 Internal change to use CCS Frontend fixtures to test the CCS frontend components.
 This included some minor changes to the HTML for the components.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ccs-frontend_helpers (0.4.0)
+    ccs-frontend_helpers (0.5.0.beta0)
       rails (>= 6.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Snyk is used more for analysing security issues and it will raise PRs itself for
    - if the changelog has headings from a pre release, regroup the content under those headings in a single block
    - saving your changes
 
-6. Run `./bin/build-release` to:
+6. Run `./bin/build-release.sh` to:
 
    - commit the changes
    - push a branch to GitHub

--- a/lib/ccs/frontend_helpers/version.rb
+++ b/lib/ccs/frontend_helpers/version.rb
@@ -2,6 +2,6 @@
 
 module CCS
   module FrontendHelpers
-    VERSION = '0.4.0'
+    VERSION = '0.5.0.beta0'
   end
 end


### PR DESCRIPTION
Internal change to use CCS Frontend fixtures to test the CCS frontend components.
This included some minor changes to the HTML for the components.