### PR TITLE
Release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.5.0-beta1] - 2024-06-07
+## [1.0.0] - 2024-06-07
 
 ### Changed
 
+- First major release of gem
 - Internal change to use CCS Frontend fixtures to test the CCS frontend components.
   This included some minor changes to the HTML for the components.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ccs-frontend_helpers (0.5.0.beta1)
+    ccs-frontend_helpers (1.0.0)
       rails (>= 6.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -14,10 +14,11 @@ The following table shows the version of CCS Frontend Helpers that you should us
 
 | CCS Frontend Helpers Version  | Target GOV.UK Frontend Version | Target CCS Frontend Version |
 | ----------------------------- | ------------------------------ | --------------------------- |
-| [0.4.0](https://github.com/Crown-Commercial-Service/ccs-frontend_helpers/releases/tag/v0.4.0) | [5.4.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.4.0) | [1.0.0-beta.5](https://github.com/tim-s-ccs/ccs-frontend-project/releases/tag/v1.0.0-beta.5) |
-| [0.3.0](https://github.com/Crown-Commercial-Service/ccs-frontend_helpers/releases/tag/v0.3.0) | [5.3.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.3.0) | [1.0.0-beta.5](https://github.com/tim-s-ccs/ccs-frontend-project/releases/tag/v1.0.0-beta.5) |
-| [0.2.0](https://github.com/Crown-Commercial-Service/ccs-frontend_helpers/releases/tag/v0.2.0) | [5.2.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.2.0) | [1.0.0-beta.5](https://github.com/tim-s-ccs/ccs-frontend-project/releases/tag/v1.0.0-beta.5) |
-| [0.1.2](https://github.com/Crown-Commercial-Service/ccs-frontend_helpers/releases/tag/v0.1.2) | [4.7.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.7.0) | [1.0.0-beta.5](https://github.com/tim-s-ccs/ccs-frontend-project/releases/tag/v1.0.0-beta.5) |
+| [1.0.0](https://github.com/Crown-Commercial-Service/ccs-frontend_helpers/releases/tag/v1.0.0) | [5.4.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.4.0) | [1.0.0-beta.5](https://github.com/tim-s-ccs/ccs-frontend-project/releases/tag/v1.0.0) |
+| [0.4.0](https://github.com/Crown-Commercial-Service/ccs-frontend_helpers/releases/tag/v0.4.0) | [5.4.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.4.0) | N/A |
+| [0.3.0](https://github.com/Crown-Commercial-Service/ccs-frontend_helpers/releases/tag/v0.3.0) | [5.3.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.3.0) | N/A |
+| [0.2.0](https://github.com/Crown-Commercial-Service/ccs-frontend_helpers/releases/tag/v0.2.0) | [5.2.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.2.0) | N/A |
+| [0.1.2](https://github.com/Crown-Commercial-Service/ccs-frontend_helpers/releases/tag/v0.1.2) | [4.7.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.7.0) | N/A |
 
 Any other versions of GOV.UK Frontend not shown above _may_ still be compatible, but have not been specifically tested and verified.
 

--- a/lib/ccs/frontend_helpers/version.rb
+++ b/lib/ccs/frontend_helpers/version.rb
@@ -2,6 +2,6 @@
 
 module CCS
   module FrontendHelpers
-    VERSION = '0.5.0.beta1'
+    VERSION = '1.0.0'
   end
 end


### PR DESCRIPTION
### Changed

- First major release of gem
- Internal change to use CCS Frontend fixtures to test the CCS frontend components.
  This included some minor changes to the HTML for the components.
