### PR TITLE
Release v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2024-09-02
+
 ### Added
 
 - Update to CCS Frontend v1.1.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ccs-frontend_helpers (1.1.2)
+    ccs-frontend_helpers (1.2.0)
       rails (>= 6.0)
 
 GEM
@@ -127,7 +127,7 @@ GEM
     mini_mime (1.1.5)
     minitest (5.25.1)
     mutex_m (0.2.0)
-    net-imap (0.4.14)
+    net-imap (0.4.15)
       date
       net-protocol
     net-pop (0.1.2)
@@ -241,7 +241,7 @@ GEM
     simplecov_json_formatter (0.1.4)
     stringio (3.1.1)
     tdiff (0.4.0)
-    thor (1.3.1)
+    thor (1.3.2)
     timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -253,7 +253,7 @@ GEM
     xpath (3.2.0)
       nokogiri (~> 1.8)
     yard (0.9.36)
-    zeitwerk (2.6.17)
+    zeitwerk (2.6.18)
 
 PLATFORMS
   x86_64-darwin-19

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The following table shows the version of CCS Frontend Helpers that you should us
 
 | CCS Frontend Helpers Version  | Target GOV.UK Frontend Version | Target CCS Frontend Version |
 | ----------------------------- | ------------------------------ | --------------------------- |
+| [1.2.0](https://github.com/Crown-Commercial-Service/ccs-frontend_helpers/releases/tag/v1.2.0) | [5.6.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.6.0) | [1.1.3](https://github.com/Crown-Commercial-Service/ccs-frontend-project/releases/tag/v1.1.3) |
 | [1.1.2](https://github.com/Crown-Commercial-Service/ccs-frontend_helpers/releases/tag/v1.1.2) | [5.5.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.5.0) | [1.1.2](https://github.com/Crown-Commercial-Service/ccs-frontend-project/releases/tag/v1.1.2) |
 | [1.1.1](https://github.com/Crown-Commercial-Service/ccs-frontend_helpers/releases/tag/v1.1.1) | [5.4.1](https://github.com/alphagov/govuk-frontend/releases/tag/v5.4.1) | [1.1.1](https://github.com/Crown-Commercial-Service/ccs-frontend-project/releases/tag/v1.1.1) |
 | [1.1.0](https://github.com/Crown-Commercial-Service/ccs-frontend_helpers/releases/tag/v1.1.0) | [5.4.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.4.0) | [1.1.0](https://github.com/Crown-Commercial-Service/ccs-frontend-project/releases/tag/v1.1.0) |

--- a/lib/ccs/frontend_helpers/version.rb
+++ b/lib/ccs/frontend_helpers/version.rb
@@ -2,6 +2,6 @@
 
 module CCS
   module FrontendHelpers
-    VERSION = '1.1.2'
+    VERSION = '1.2.0'
   end
 end


### PR DESCRIPTION
### Added

- Update to CCS Frontend v1.1.3
- Update to GOV.UK Frontend v5.6.0
- The following GOV.UK helpers have been added:
  - Service navigation
