### PR TITLE
Release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0] - 2024-11-05
+
 ### Changed
 
 - Update minimum required Rails version to v7.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ccs-frontend_helpers (1.2.0)
+    ccs-frontend_helpers (2.0.0)
       rails (>= 7.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The following table shows the version of CCS Frontend Helpers that you should us
 
 | CCS Frontend Helpers Version  | Target GOV.UK Frontend Version | Target CCS Frontend Version |
 | ----------------------------- | ------------------------------ | --------------------------- |
+| [2.0.0](https://github.com/Crown-Commercial-Service/ccs-frontend_helpers/releases/tag/v2.0.0) | [5.7.1](https://github.com/alphagov/govuk-frontend/releases/tag/v5.7.1) | [1.2.0](https://github.com/Crown-Commercial-Service/ccs-frontend-project/releases/tag/v1.2.0) |
 | [1.2.0](https://github.com/Crown-Commercial-Service/ccs-frontend_helpers/releases/tag/v1.2.0) | [5.6.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.6.0) | [1.1.3](https://github.com/Crown-Commercial-Service/ccs-frontend-project/releases/tag/v1.1.3) |
 | [1.1.2](https://github.com/Crown-Commercial-Service/ccs-frontend_helpers/releases/tag/v1.1.2) | [5.5.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.5.0) | [1.1.2](https://github.com/Crown-Commercial-Service/ccs-frontend-project/releases/tag/v1.1.2) |
 | [1.1.1](https://github.com/Crown-Commercial-Service/ccs-frontend_helpers/releases/tag/v1.1.1) | [5.4.1](https://github.com/alphagov/govuk-frontend/releases/tag/v5.4.1) | [1.1.1](https://github.com/Crown-Commercial-Service/ccs-frontend-project/releases/tag/v1.1.1) |

--- a/lib/ccs/frontend_helpers/version.rb
+++ b/lib/ccs/frontend_helpers/version.rb
@@ -2,6 +2,6 @@
 
 module CCS
   module FrontendHelpers
-    VERSION = '1.2.0'
+    VERSION = '2.0.0'
   end
 end


### PR DESCRIPTION
### Changed

- Update minimum required Rails version to v7.0
- Updated minimum Ruby version to 3.1

### Added

- Updated GOV.UK Frontend to v5.7.1
- Updated CCS Frontend to v1.2.0