### PR TITLE
Release v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0] - 2025-03-21
+
 ### Added
 
 - Add support for to ruby v3.4
+- Updated GOV.UK Frontend to v5.9.0
+- Updated CCS Frontend to v1.3.3
 
 ## [2.1.0] - 2025-01-08
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ccs-frontend_helpers (2.1.0)
+    ccs-frontend_helpers (2.2.0)
       rails (>= 7.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The following table shows the version of CCS Frontend Helpers that you should us
 
 | CCS Frontend Helpers Version  | Target GOV.UK Frontend Version | Target CCS Frontend Version |
 | ----------------------------- | ------------------------------ | --------------------------- |
+| [2.2.0](https://github.com/Crown-Commercial-Service/ccs-frontend_helpers/releases/tag/v2.2.0) | [5.9.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.9.0) | [1.3.3](https://github.com/Crown-Commercial-Service/ccs-frontend-project/releases/tag/v1.3.3) |
 | [2.1.0](https://github.com/Crown-Commercial-Service/ccs-frontend_helpers/releases/tag/v2.1.0) | [5.7.1](https://github.com/alphagov/govuk-frontend/releases/tag/v5.7.1) | [1.3.2](https://github.com/Crown-Commercial-Service/ccs-frontend-project/releases/tag/v1.3.2) |
 | [2.0.0](https://github.com/Crown-Commercial-Service/ccs-frontend_helpers/releases/tag/v2.0.0) | [5.7.1](https://github.com/alphagov/govuk-frontend/releases/tag/v5.7.1) | [1.2.0](https://github.com/Crown-Commercial-Service/ccs-frontend-project/releases/tag/v1.2.0) |
 | [1.2.0](https://github.com/Crown-Commercial-Service/ccs-frontend_helpers/releases/tag/v1.2.0) | [5.6.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.6.0) | [1.1.3](https://github.com/Crown-Commercial-Service/ccs-frontend-project/releases/tag/v1.1.3) |

--- a/lib/ccs/frontend_helpers/version.rb
+++ b/lib/ccs/frontend_helpers/version.rb
@@ -2,6 +2,6 @@
 
 module CCS
   module FrontendHelpers
-    VERSION = '2.1.0'
+    VERSION = '2.2.0'
   end
 end


### PR DESCRIPTION
### Added

- Add support for to ruby v3.4
- Updated GOV.UK Frontend to v5.9.0
- Updated CCS Frontend to v1.3.3