### PR TITLE
Release v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0] - 2025-08-27
+
 ### Added
 
 - Updated CCS Frontend to v2.0.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ccs-frontend_helpers (5.5.0)
+    ccs-frontend_helpers (3.0.0)
       rails (>= 7.2)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The following table shows the version of CCS Frontend Helpers that you should us
 
 | CCS Frontend Helpers Version  | Target GOV.UK Frontend Version | Target CCS Frontend Version |
 | ----------------------------- | ------------------------------ | --------------------------- |
+| [3.0.0](https://github.com/Crown-Commercial-Service/ccs-frontend_helpers/releases/tag/v3.0.0) | [5.11.2](https://github.com/alphagov/govuk-frontend/releases/tag/v5.11.2) | [2.0.0](https://github.com/Crown-Commercial-Service/ccs-frontend-project/releases/tag/v2.0.0) |
 | [2.5.0](https://github.com/Crown-Commercial-Service/ccs-frontend_helpers/releases/tag/v2.5.0) | [5.11.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.11.0) | [1.4.1](https://github.com/Crown-Commercial-Service/ccs-frontend-project/releases/tag/v1.4.1) |
 | [2.4.0](https://github.com/Crown-Commercial-Service/ccs-frontend_helpers/releases/tag/v2.4.0) | [5.10.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.10.0) | [1.4.1](https://github.com/Crown-Commercial-Service/ccs-frontend-project/releases/tag/v1.4.1) |
 | [2.3.0](https://github.com/Crown-Commercial-Service/ccs-frontend_helpers/releases/tag/v2.3.0) | [5.9.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.9.0) | [1.4.0](https://github.com/Crown-Commercial-Service/ccs-frontend-project/releases/tag/v1.4.0) |

--- a/lib/ccs/frontend_helpers/version.rb
+++ b/lib/ccs/frontend_helpers/version.rb
@@ -2,6 +2,6 @@
 
 module CCS
   module FrontendHelpers
-    VERSION = '5.5.0'
+    VERSION = '3.0.0'
   end
 end


### PR DESCRIPTION
### Added

- Updated CCS Frontend to v2.0.0

### Removed

- The CCS Header is now just the logo as all other parts should now go in the GOV.UK Service Navigation component
